### PR TITLE
GL early stopping criterion implemented

### DIFF
--- a/GPErks/gpe.py
+++ b/GPErks/gpe.py
@@ -11,7 +11,7 @@ import torch
 
 from GPErks.data import ScaledData
 from GPErks.utils.earlystopping import EarlyStoppingCriterion, \
-    NoEarlyStoppingCriterion
+    NoEarlyStoppingCriterion, GLEarlyStoppingCriterion
 from GPErks.utils.log import get_logger
 from GPErks.utils.metrics import get_metric_name
 from GPErks.utils.tensor import tensorize

--- a/GPErks/tests/test_1.py
+++ b/GPErks/tests/test_1.py
@@ -16,7 +16,7 @@ from GPErks.gpe import LEARNING_RATE, GPEmul
 from GPErks.models.models import ExactGPModel, LinearMean
 from GPErks.utils.design import read_labels
 from GPErks.utils.earlystopping import FixedEpochEarlyStoppingCriterion, \
-    NoEarlyStoppingCriterion
+    NoEarlyStoppingCriterion, GLEarlyStoppingCriterion
 from GPErks.utils.log import get_logger
 from GPErks.utils.metrics import IndependentStandardError as ISE
 from GPErks.utils.preprocessing import StandardScaler, UnitCubeScaler
@@ -114,8 +114,9 @@ def main():
     )
 
     optimizer = torch.optim.Adam(model.parameters(), lr=LEARNING_RATE)
-    esc = FixedEpochEarlyStoppingCriterion(88)
+    # esc = FixedEpochEarlyStoppingCriterion(88)
     # esc = NoEarlyStoppingCriterion()  # TODO: investigate if snapshot is required anyway
+    esc = GLEarlyStoppingCriterion(alpha=1.0, patience=8)
 
     # device=torch.device('cpu')
     emul = GPEmul(train_scaled_data, model, optimizer, metrics)

--- a/GPErks/utils/train_stats.py
+++ b/GPErks/utils/train_stats.py
@@ -16,11 +16,19 @@ class TrainStats:
             metric_name: []
             for metric_name in metrics_names
         }
+        self.early_stopping_enabled: Bool = False
         print('')
 
     @property
     def idx_best(self):
-        if len(self.val_loss) > 0:
-            return numpy.argmin(self.val_loss)
+        if self.early_stopping_enabled:
+            return self._idx_best
         else:
-            return numpy.argmin(self.train_loss)
+            if len(self.val_loss) > 0:
+                return numpy.argmin(self.val_loss)
+            else:
+                return numpy.argmin(self.train_loss)
+
+    @idx_best.setter
+    def idx_best(self, value: int):
+        self._idx_best: int = value


### PR DESCRIPTION
First concrete example of an early stopping criterion. TrainStats needed a not so clean modification (needs review). Works for the first restart, still some bug for consecutive restarts as the ESC instance has to go back to __init__ state before the next restart.